### PR TITLE
Add query string for image calls

### DIFF
--- a/developer-documentation/000-foundation/vhost.md
+++ b/developer-documentation/000-foundation/vhost.md
@@ -68,7 +68,7 @@ server {
 
     # expire 
     location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {
-        try_files $uri /website.php/$1;
+        try_files $uri /website.php/$1?$query_string;
         access_log off;
         expires 30d;
         add_header Pragma public;


### PR DESCRIPTION
The query string must be provided to the `MediaController`.
Without it the symfony cache will always deliver the same image.